### PR TITLE
Fixing the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,11 @@ client_id=12ab34cd-56ef-78ab-90cd-1a2b3c4d5e6e
 secret=fK~8Q~anySecretAppliesHere~WhatEverWorks
 tenant=cdef7890-a4b5-5a5b-6b6c-9876543fedcb
 ```
-* Remove, create and generate certs
+* Create resources, generate certs and install VM's using Ansible
 ```
-cd ~/git/pgv_azure/
-~/.local/bin/ansible-playbook -i environments/cluster1 all.yml
+~/git/pgv_azure/create_new_cluster.sh
 ```
-* Now you can run ansible-playbook in the pgvillage repo to install pgvillage on teh newly created vms
-```
-cd ~/git/pgvillage/
-~/.local/bin/ansible-playbook -i environments/cluster1 functional-all.yml
-```
+
 ## Alternate
 * Create a CentOS VM Ansible Control Node on Azure by following [this](https://docs.microsoft.com/en-us/azure/developer/ansible/install-on-linux-vm?tabs=azure-cli#install-ansible-on-an-azure-linux-virtual-machine).
 * After that you need to manually do all things in the bootstrap script (no script available yet).


### PR DESCRIPTION
- Adding inventories and playbook for creating the VMs
- tags.applicationRole=ansible_runner
- ansible->postgres vmss with ssh
- dynamic inventory
- Adding proxy to inventory
- Testing with a scaleset of 2 for now
- Rebuilding afresh bootstrap node
- improving
- Many playbook improvements
- Using default etcd package from postgres repo adding language packs (required for rocky 9 images) no StrictHostKeyChecking for new machiens
- disabling restore_command for now. Will work with buckets later
- Enabling backup
- Splitting up azure steps in multiple task files
- Refinements while moving from one to next controlstation
- option to autogenerate .ssh/config
- bash script for creating a new cluster And autoaccepting terms
- Set LB vip in hba for 5433 to work
- dns name and cert for vip, and avchecker working
- azure_storage_account_name set in defaults and added to inventory. so no need to set it in group_vars/all/azure.yml
- update README
