### PR TITLE
Minor fixes

### DIFF
--- a/create_new_cluster.sh
+++ b/create_new_cluster.sh
@@ -13,7 +13,7 @@ CLUSTER=${1:-cluster1}
 cd ~/git/pgv_azure && cluster_exists
 time ansible-playbook -i environments/cluster1 create_resources.yml
 echo "Sleeping 60 sec. for all scaleset vms to come alive"
-sleep 60
+sleep 90
 time ansible-playbook -i environments/cluster1 inventory.yml
 
 cd ~/git/pgvillage && cluster_exists

--- a/environments/cluster1/group_vars/all/avchecker.yml
+++ b/environments/cluster1/group_vars/all/avchecker.yml
@@ -1,5 +1,5 @@
 ---
-avchecker_cluster_members: "{{ groups['hacluster'] | list | join(',') }}"
+avchecker_cluster_members: "{% set nodes = [] %}{% for node in groups['hacluster'] %}{% do nodes.append(hostvars[node].ansible_facts.fqdn) %}{% endfor %}{{ nodes | list | join(',') }}"
 
 avchecker_defaults:
   stolon:

--- a/roles/chainsmith/defaults/main.yml
+++ b/roles/chainsmith/defaults/main.yml
@@ -24,14 +24,18 @@ chainsmith_server_intermediate:
     - serverAuth
   servers: "{{ chainsmith_servers }}"
 
+chainsmith_internal_clients:
+ - postgres
+ - application
+ - avchecker
+ - pgquartz
+ - pgfga
+
+chainsmith_external_clients: []
+
 chainsmith_client_intermediate:
   name: client
-  clients:
-    - postgres
-    - application
-    - avchecker
-    - pgquartz
-    - pgfga
+  clients: "{{ chainsmith_internal_clients + chainsmith_external_clients }}"
   keyUsages:
     - keyEncipherment
     - dataEncipherment

--- a/roles/chainsmith/tasks/main.yml
+++ b/roles/chainsmith/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 # tasks file for chainsmith
-#- name: debug
-#  debug:
-#    msg: "{{ chainsmith_servers }}"
+- name: debug
+  debug:
+    msg: "{{ chainsmith_servers }}"
 
 - name: install
   import_tasks: install.yml


### PR DESCRIPTION
- Adding inventories and playbook for creating the VMs
- tags.applicationRole=ansible_runner
- ansible->postgres vmss with ssh
- dynamic inventory
- Adding proxy to inventory
- Testing with a scaleset of 2 for now
- Rebuilding afresh bootstrap node
- improving
- Many playbook improvements
- Using default etcd package from postgres repo adding language packs (required for rocky 9 images) no StrictHostKeyChecking for new machiens
- disabling restore_command for now. Will work with buckets later
- Enabling backup
- Splitting up azure steps in multiple task files
- Refinements while moving from one to next controlstation
- option to autogenerate .ssh/config
- bash script for creating a new cluster And autoaccepting terms
- Set LB vip in hba for 5433 to work
- dns name and cert for vip, and avchecker working
- azure_storage_account_name set in defaults and added to inventory. so no need to set it in group_vars/all/azure.yml
- update README
- wait 90 secs instead of 60
- avchecker nodes with fqdn
- Chainsmith small fixes
